### PR TITLE
Achievements and AchievementItem components, with accenting

### DIFF
--- a/app/components/stats/achievement-item.hbs
+++ b/app/components/stats/achievement-item.hbs
@@ -1,1 +1,22 @@
-<h1>Achievement Item</h1>
+<div class="flex flex-row gap-2 items-center">
+  <img
+    src="https://avatars.akamai.steamstatic.com/3ea5c1a79dbebd35ad9e5e5ca7ca4db8b3107cac_full.jpg"
+    alt="Achievement Icon"
+    width="64"
+  />
+  <div class="flex flex-col w-full">
+    <h1 class="text-2xl text-primary-dark leading-none">{{@achievement}}</h1>
+    <p class="text-secondary-dark">Light bonfire flame.</p>
+
+    <div class="flex flex-row justify-between">
+      <div class="flex">
+        <p class="text-secondary-dark">Achieved on:&nbsp;</p>
+        <p class="text-accent-dark">Aug 14, 2024</p>
+      </div>
+      <div class="flex">
+        <p class="text-secondary-dark">Rarity:&nbsp;</p>
+        <p class="text-accent-dark">73.6%</p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/stats/achievements.hbs
+++ b/app/components/stats/achievements.hbs
@@ -1,3 +1,14 @@
-<div data-test-achievements class="flex w-full max-w-3xl bg-header-dark">
-  <h1 class="text-2xl text-primary-dark">Achievements</h1>
+<div
+  data-test-achievements
+  class="flex flex-col w-full max-w-3xl bg-header-dark rounded-md drop-shadow-md px-4 py-2 gap-4"
+>
+  <div class="flex flex-row justify-between items-baseline">
+    <h1 class="text-4xl text-primary-dark">Achievements</h1>
+    <button class="text-xl text-primary-dark px-2" type="button">Sort</button>
+  </div>
+  <ul class="flex flex-col gap-4">
+    {{#each this.achievements as |achievement|}}
+      <Stats::AchievementItem @achievement={{achievement}} />
+    {{/each}}
+  </ul>
 </div>

--- a/app/components/stats/achievements.ts
+++ b/app/components/stats/achievements.ts
@@ -1,3 +1,5 @@
 import Component from '@glimmer/component';
 
-export default class StatsAchievements extends Component {}
+export default class StatsAchievements extends Component {
+  achievements = ['Enkindle', 'Estus Flask', 'Lordran'];
+}

--- a/tests/integration/components/stats/achievement-item-test.js
+++ b/tests/integration/components/stats/achievement-item-test.js
@@ -10,8 +10,8 @@ module('Integration | Component | stats/achievement-item', function (hooks) {
     // Set any properties with this.set('myProperty', 'value');
     // Handle any actions with this.set('myAction', function(val) { ... });
 
-    await render(hbs`<Stats::AchievementItem />`);
+    await render(hbs`<Stats::AchievementItem @achievement="achievement"/>`);
 
-    assert.dom('h1').hasText('Achievement Item');
+    assert.dom('h1').hasText('achievement');
   });
 });


### PR DESCRIPTION
Achievements and AchievementItems match Figma design

Refactors:
- removed horizontal lines between Achievementitems
- accented date and rarity